### PR TITLE
Unwrap Promise from action handler result since we await it already

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -23,7 +23,9 @@ function serverAction<In, Ls extends Record<any, any> = {}>(opts: {
     },
 
     handler: (fn) => {
-      return async function action(input: In) {
+      return async function action(
+        input: In
+      ): Promise<Awaited<ReturnType<typeof fn>>> {
         const parsedInput = opts.schema?.parse(input) || input;
         // internal locals type, won't be exposed so we can assert
         let acc = {} as Ls;
@@ -43,3 +45,10 @@ function serverAction<In, Ls extends Record<any, any> = {}>(opts: {
 export function createServerAction() {
   return serverAction({ middleware: [] });
 }
+
+const exampleAction = createServerAction()
+  .input(z.object({ name: z.string() }))
+  .use(async (input, locals) => ({
+    testLocal: 1,
+  }))
+  .handler(async (input, locals) => {});

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ type MiddlewareFn<In, Ls, Out> = (input: In, locals: Ls) => Promise<Out>;
 
 type HandlerFn<In, Ls> = <R>(
   fn: (input: In, locals: Ls) => R
-) => (input: In) => Promise<R>;
+) => (input: In) => Promise<Awaited<R>>;
 
 interface ServerAction<In, Ls> {
   input: InputSetterFn<In, Ls>;


### PR DESCRIPTION
In the case where the action handler is a Promise, we had nested promises since the return of a Handler is a Promise awaiting the passed function. We are explicitly typing it as awaited since we first await all middlewares and then return the awaited result of the actual action handler.